### PR TITLE
fix: migrate prism to highlightjs

### DIFF
--- a/web/src/components/ChatLog/ChatMessage/index.jsx
+++ b/web/src/components/ChatLog/ChatMessage/index.jsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Markdown from "react-markdown";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import remarkGfm from "remark-gfm";
-import { darcula } from "react-syntax-highlighter/dist/esm/styles/prism";
+import { darcula } from "react-syntax-highlighter/dist/esm/styles/hljs";
 
 import Avatar from "@mui/material/Avatar";
 import Tooltip from "@mui/material/Tooltip";


### PR DESCRIPTION
## Pull Request Checklist

- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Prism seems to be broken after I upgraded the version of `react-syntax-highlighter` and `react-markdown`, switching to highlightjs seems to solve this problem.
