### PR TITLE
fix: switch summarization prompt role from system to user

### DIFF
--- a/api/chatbot/chains/summarization.py
+++ b/api/chatbot/chains/summarization.py
@@ -8,7 +8,7 @@ tmpl = ChatPromptTemplate.from_messages(
         ("system", instruction),
         MessagesPlaceholder(variable_name="history"),
         (
-            "system",
+            "user",
             "Now Provide a short summarization of the conversation in less than 10 words.",
         ),
     ]


### PR DESCRIPTION
## Pull Request Checklist

- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Some LLM's chat_template only supports one leading system message, followed by human - assistant message loop.

For example the vicuna chat_template, which is also used by WizardLM.
