### PR TITLE
chore: remove port-forward in docker compose file

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,4 +1,3 @@
-# forward ports in devcontainer.json
 services:
   chatbot:
     image: mcr.microsoft.com/devcontainers/python:3.12
@@ -39,8 +38,6 @@ services:
       - --no-webui
     volumes:
       - ../downloads:/data
-    ports:
-      - 8080:8080
     depends_on:
       download-weights:
         condition: service_completed_successfully


### PR DESCRIPTION
Forwarding in docker compose only forwards to the host of the container runtime (my dev server), which is not of much help.

Forwarding ports in 'non-main' container to vscode's host is not supported yet. See <https://github.com/microsoft/vscode-remote-release/issues/4645>

## Pull Request Checklist

- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
