### PR TITLE
refactor: push overflow to chatlog

### DIFF
--- a/web/src/components/ChatLog/index.jsx
+++ b/web/src/components/ChatLog/index.jsx
@@ -1,3 +1,5 @@
+import styles from "./index.module.css";
+
 import { useCallback, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 
@@ -9,7 +11,7 @@ import PropTypes from "prop-types";
  * @param {string} [props.className] - Additional CSS classes for the chat log container.
  * @param {boolean} [props.smoothScroll=true] - Whether to enable smooth scrolling.
  */
-const ChatLog = ({ children, className = "", smoothScroll = true }) => {
+const ChatLog = ({ children, smoothScroll = true }) => {
     const chatLogRef = useRef(null);
     const messagesEndRef = useRef(null);
 
@@ -37,7 +39,7 @@ const ChatLog = ({ children, className = "", smoothScroll = true }) => {
     }, [scrollToBottom]);
 
     return (
-        <div ref={chatLogRef} className={className} role="region" aria-label="chat-log">
+        <div ref={chatLogRef} className={styles.chatLog} role="region" aria-label="chat-log">
             {children}
             <div ref={messagesEndRef} />
         </div>

--- a/web/src/components/ChatLog/index.module.css
+++ b/web/src/components/ChatLog/index.module.css
@@ -1,0 +1,6 @@
+.chatLog {
+    overflow-y: auto;
+    scroll-behavior: smooth;
+    scrollbar-color: var(--border-color) transparent;
+    scrollbar-width: thin;
+}

--- a/web/src/components/ChatLog/index.test.jsx
+++ b/web/src/components/ChatLog/index.test.jsx
@@ -30,18 +30,6 @@ describe("ChatLog Component", () => {
         expect(screen.getByText("Message 2")).toBeDefined();
     });
 
-    it("applies the provided className", () => {
-        const customClass = "custom-class";
-        render(
-            <ChatLog className={customClass}>
-                <div>Message</div>
-            </ChatLog>
-        );
-
-        const chatLogElement = screen.getByRole("region", { name: /chat-log/i });
-        expect(chatLogElement.classList).toContain(customClass);
-    });
-
     it("scrolls to the bottom when ResizeObserver triggers", () => {
         const observeMock = vi.spyOn(ResizeObserver.prototype, "observe");
         render(

--- a/web/src/components/ChatMessage/index.module.css
+++ b/web/src/components/ChatMessage/index.module.css
@@ -7,6 +7,7 @@
     margin-left: auto;
     margin-right: auto;
     padding-top: 1vw;
+    text-align: left;
 }
 
 .messageContainer.mine {

--- a/web/src/routes/conversation/index.jsx
+++ b/web/src/routes/conversation/index.jsx
@@ -129,7 +129,7 @@ const Conversation = () => {
     return (
         <section className={`${styles.chatbox} ${navigation.state === "loading" ? "loading" : ""}`}>
             <ChatboxHeader />
-            <ChatLog className={styles.chatLog}>
+            <ChatLog>
                 {/* We ignore system messages when displaying. */}
                 {conversation && messages?.filter(message => message.from !== "system").map((message, index) => (
                     <ChatMessage key={index} convId={conversation.id} message={message} />

--- a/web/src/routes/conversation/index.module.css
+++ b/web/src/routes/conversation/index.module.css
@@ -2,10 +2,6 @@
     display: flex;
     flex-direction: column;
     flex-grow: 1;
-    overflow: auto;
-    scroll-behavior: smooth;
-    scrollbar-color: var(--border-color) transparent;
-    scrollbar-width: thin;
     border: 1px solid var(--border-color);
     background-color: var(--bg-secondary);
     position: relative;
@@ -15,10 +11,6 @@
   opacity: 0.25;
   transition: opacity 200ms;
   transition-delay: 200ms;
-}
-
-.chatLog {
-    text-align: left;
 }
 
 .inputBottom {


### PR DESCRIPTION
Before this PR, the scrolling attributes are distributed among components:
- The `ChatLog` has the function to "scroll to bottom on resize".
- The `Chatbox` has the `overflow: auto` attribute.

This PR merge these scrolling attributes into `ChatLog` (meanwhile move `text-align` out of `ChatLog`)

However, as the user is scrolling the `ChatLog` instead of the `Chatbox` now, the "fadeout" effect (`ChatboxHeader` covering `Chatbox` half transparently) is gone.

This PR also makes "scrolling detection" inside `ChatLog` possible.