### PR TITLE
chore(manifests): upgrade pgbouncer to 1.24.1

### DIFF
--- a/manifests/components/pgbouncer/kustomization.yaml
+++ b/manifests/components/pgbouncer/kustomization.yaml
@@ -25,4 +25,4 @@ secretGenerator:
 
 images:
   - name: bitnami/pgbouncer
-    newTag: 1.24.0
+    newTag: 1.24.1


### PR DESCRIPTION
Fixes CVE-2025-2291, see <https://github.com/pgbouncer/pgbouncer/releases/tag/pgbouncer_1_24_1>

## Pull Request Checklist

- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
