### PR TITLE
refactor(server): get raw connection from sqlalchemy

### DIFF
--- a/api/chatbot/config.py
+++ b/api/chatbot/config.py
@@ -1,31 +1,10 @@
 from __future__ import annotations
 
-import re
 from typing import Any
 
 from pydantic import BaseModel, Field, PostgresDsn, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Self
-
-
-def remove_postgresql_variants(dsn: str) -> str:
-    """Remove the 'driver' part from a connection string, if one is present in the URI scheme.
-
-    ORM libraries like SQLAlchemy require the driver part for non-default drivers.
-    For example, SQLAlchemy defaults to psycopg2 for PostgreSQL, so one need to specify
-    'postgresql+psycopg' as the scheme for using psycopg3.
-
-    In contrast, psycopg3 itself only accepts the URL scheme supported by PostgreSQL, which is 'postgresql'.
-
-    Args:
-        dsn (str): The original connection string.
-
-    Returns:
-        str: Connection string with the driver part removed.
-    """
-    pattern = r"postgresql\+psycopg(?:2(?:cffi)?)?"
-
-    return re.sub(pattern, "postgresql", dsn)
 
 
 class S3Settings(BaseModel):
@@ -41,12 +20,12 @@ class Settings(BaseSettings):
 
     llm: dict[str, Any] = Field(default_factory=lambda: {"api_key": "NOT_SET"})
     safety_llm: dict[str, Any] | None = None
-    postgres_primary_url: PostgresDsn = (
+    postgres_primary_url: PostgresDsn | str = (
         "postgresql+psycopg://postgres:postgres@localhost:5432/"
     )
-    """Primary database url. Read/Write. Must be a valid postgresql connection string."""
-    postgres_standby_url: PostgresDsn | None = None
-    """Standby database url. Read Only. If present must be a valid postgresql connection string.
+    """Primary database url for read / write connections."""
+    postgres_standby_url: PostgresDsn | str | None = None
+    """Standby database url for read only connections.
     Defaults to `postgres_primary_url`.
     """
 
@@ -61,14 +40,6 @@ class Settings(BaseSettings):
         if self.postgres_standby_url is None:
             self.postgres_standby_url = self.postgres_primary_url
         return self
-
-    @property
-    def psycopg_primary_url(self) -> str:
-        return remove_postgresql_variants(str(self.postgres_primary_url))
-
-    @property
-    def psycopg_standby_url(self) -> str:
-        return remove_postgresql_variants(str(self.postgres_standby_url))
 
 
 settings = Settings()

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -1,29 +1,6 @@
 import unittest
 
-from chatbot.config import Settings, remove_postgresql_variants
-from pydantic import ValidationError
-
-
-class TestRemovePostgresqlVariants(unittest.TestCase):
-    def test_remove_psycopg(self):
-        dsn = "postgresql+psycopg://user:pass@localhost/dbname"
-        expected = "postgresql://user:pass@localhost/dbname"
-        self.assertEqual(remove_postgresql_variants(dsn), expected)
-
-    def test_remove_psycopg2(self):
-        dsn = "postgresql+psycopg2://user:pass@localhost/dbname"
-        expected = "postgresql://user:pass@localhost/dbname"
-        self.assertEqual(remove_postgresql_variants(dsn), expected)
-
-    def test_remove_psycopg2cffi(self):
-        dsn = "postgresql+psycopg2cffi://user:pass@localhost/dbname"
-        expected = "postgresql://user:pass@localhost/dbname"
-        self.assertEqual(remove_postgresql_variants(dsn), expected)
-
-    def test_no_change(self):
-        dsn = "postgresql://user:pass@localhost/dbname"
-        expected = "postgresql://user:pass@localhost/dbname"
-        self.assertEqual(remove_postgresql_variants(dsn), expected)
+from chatbot.config import Settings
 
 
 class TestSettings(unittest.TestCase):
@@ -61,38 +38,6 @@ class TestSettings(unittest.TestCase):
         settings = Settings(postgres_standby_url=custom_standby_url)
         expected = "postgresql+psycopg://standby_user:standby_pass@localhost/standby_db"
         self.assertEqual(str(settings.postgres_standby_url), expected)
-
-    def test_invalid_db_url(self):
-        with self.assertRaises(ValidationError):
-            Settings(postgres_primary_url="invalid_url")
-        with self.assertRaises(ValidationError):
-            Settings(postgres_standby_url="invalid_url")
-
-    def test_psycopg_primary_url_default(self):
-        settings = Settings()
-        expected = "postgresql://postgres:postgres@localhost:5432/"
-        self.assertEqual(settings.psycopg_primary_url, expected)
-
-    def test_psycopg_primary_url_custom(self):
-        custom_primary_url = (
-            "postgresql+psycopg://primary_user:primary_pass@localhost/primary_db"
-        )
-        settings = Settings(postgres_primary_url=custom_primary_url)
-        expected = "postgresql://primary_user:primary_pass@localhost/primary_db"
-        self.assertEqual(settings.psycopg_primary_url, expected)
-
-    def test_psycopg_standby_url_default(self):
-        settings = Settings()
-        expected = "postgresql://postgres:postgres@localhost:5432/"
-        self.assertEqual(settings.psycopg_standby_url, expected)
-
-    def test_psycopg_standby_url_custom(self):
-        custom_standby_url = (
-            "postgresql+psycopg://standby_user:standby_pass@localhost/standby_db"
-        )
-        settings = Settings(postgres_standby_url=custom_standby_url)
-        expected = "postgresql://standby_user:standby_pass@localhost/standby_db"
-        self.assertEqual(settings.psycopg_standby_url, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Instead of infering the connection string from config, this commit directly get the raw connect object from sqlalchemy

## Pull Request Checklist

- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
