### PR TITLE
fix: allow extra env when loading from dotenv file

### DIFF
--- a/api/chatbot/config.py
+++ b/api/chatbot/config.py
@@ -19,7 +19,7 @@ class S3Settings(BaseModel):
 
 
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_nested_delimiter="__")
+    model_config = SettingsConfigDict(env_nested_delimiter="__", extra="ignore")
 
     llm: ChatOpenAI
     safety_llm: ChatOpenAI | None = None


### PR DESCRIPTION
> Pydantic settings consider extra config in case of dotenv file. It means if you set the extra=forbid (default) on model_config and your dotenv file contains an entry for a field that is not defined in settings model, it will raise ValidationError in settings construction.

See <https://docs.pydantic.dev/latest/concepts/pydantic_settings/#dotenv-env-support>

## Pull Request Checklist

- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
