### PR TITLE
fix: avoid using response schema and tools simultaneously

### DIFF
--- a/api/chatbot/agent/__init__.py
+++ b/api/chatbot/agent/__init__.py
@@ -125,7 +125,8 @@ Current date: {date}
                     logger.warning(
                         "Tool picker not working properly, you should check whether your model supports `json_schema`."
                     )
-                elif tool_names := parsed.tool_names:
+                # NOTE: Don't emit the `is not None` check, the `parsed.tool_names` might be an empty list.
+                elif (tool_names := parsed.tool_names) is not None:
                     selected_tools = [tool for tool in tools if tool.name in tool_names]
             except Exception:
                 logger.exception("Error picking tools, binding all")

--- a/api/chatbot/agent/toolpicker.py
+++ b/api/chatbot/agent/toolpicker.py
@@ -43,7 +43,7 @@ def create_tool_picker(
     ToolNamesType: TypeAlias = list[Literal[*tool_names]] | None  # type: ignore
 
     valid_options = [
-        "- `None`: No tool needed. You can answer based on your existing knowledge, or the task does not require fetching external information."
+        "- `None`: No tool needed -- you can answer based on your existing knowledge, or the task does not require fetching external information."
     ] + [f"- `{tool.name}`: {tool.description}" for tool in tools]
 
     class PickTools(BaseModel):
@@ -77,7 +77,6 @@ def create_tool_picker(
         method="json_schema",
         strict=True,
         include_raw=True,
-        tools=[PickTools],
     ).with_config(tags=["internal"])
 
     # Disable internal "thinking" behavior when using reasoning models.


### PR DESCRIPTION
Using both at the same time causes OpenAI to return only `tool_calls` without any `content`, which breaks the `parsed` field that depends on `content`.

This previously appeared to work due to incorrect behavior in VLLM.

## Pull Request Checklist

- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
