### PR TITLE
fix: the browsertool accepts a `url` parameter as a ... in browser.py

### DIFF
--- a/api/chatbot/tools/browser.py
+++ b/api/chatbot/tools/browser.py
@@ -1,4 +1,6 @@
+import ipaddress
 import logging
+from urllib.parse import urlparse
 
 from aiohttp import ClientResponseError
 from bs4 import BeautifulSoup, Comment
@@ -10,7 +12,7 @@ from langchain_core.callbacks import (
 from langchain_core.tools import BaseTool, ToolException
 from langchain_core.tools.base import ArgsSchema
 from markdownify import markdownify as md
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from requests.exceptions import HTTPError
 
 from chatbot.http_client import HttpClient
@@ -23,6 +25,25 @@ class BrowserInput(BaseModel):
     """Input params for BrowserTool."""
 
     url: str = Field(description="The url you want to visit.")
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, v: str) -> str:
+        parsed = urlparse(v)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError("URL scheme must be http or https")
+        hostname = parsed.hostname or ""
+        try:
+            addr = ipaddress.ip_address(hostname)
+            if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
+                raise ValueError("Requests to private/internal addresses are not allowed")
+        except ValueError as exc:
+            if "not allowed" in str(exc):
+                raise
+            # hostname is a domain name; block well-known internal names
+            if hostname in ("localhost",) or hostname.endswith(".internal") or hostname.endswith(".local"):
+                raise ValueError("Requests to internal hostnames are not allowed")
+        return v
 
 
 ua = UserAgent()


### PR DESCRIPTION
## Summary
Address high severity security finding in `api/chatbot/tools/browser.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `api/chatbot/tools/browser.py:22` |
| **Assessment** | Likely exploitable |

**Description**: The BrowserTool accepts a `url` parameter as a plain string with no validation, allowlist, or scheme restriction. The Pydantic model `BrowserInput` only declares `url: str` with no constraints. This allows an LLM-driven or direct API caller to supply arbitrary URLs including internal network addresses, causing the server to make requests to internal services.

## Evidence

**Exploitation scenario**: An attacker who can interact with the chatbot API instructs the LLM to use the web_browser tool with url='http://169.254.169.254/latest/meta-data/iam/security-credentials/'.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

## Threat Model Context

This is a containerized service - vulnerabilities may be exploitable depending on network exposure.

## Changes
- `api/chatbot/tools/browser.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
